### PR TITLE
If the lookup doesn't work, attempt to reference the commit as a tag.

### DIFF
--- a/Adapters/LibGit2SharpRepository.cs
+++ b/Adapters/LibGit2SharpRepository.cs
@@ -243,7 +243,15 @@ namespace CheckRelease.Adapters
             try
             {
                 var commit = _repository.Lookup<Commit>(reference);
-                if (commit == null) return null;
+                if (commit == null)
+                {
+                    var tag = GetTag(reference);
+                    if (tag == null || String.IsNullOrWhiteSpace(tag.TargetCommitSha))
+                    {
+                        return null;
+                    }
+                    commit = _repository.Lookup<Commit>(tag.TargetCommitSha);
+                }
                 
                 var tree = commit.Tree;
                 var treeEntry = tree[filePath];


### PR DESCRIPTION
## Description

Add an additional attempt to look up a tag by name if the first pass doesn't resolve.  For some reason, the occasional tag name can't be referenced the traditional way, so this adds a fallback that appears to work in all cases.

Fixes # (issue)

"Error: Could not extract appsettings.json from tag/commit 'release/S105.01/uat'. The file may not exist at this path in this commit, or there might be an issue accessing the Git repository."

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)

## SEMVER Impact
- [ X ] Patch (bug fixes, documentation updates)

## How Has This Been Tested?

Run against failing examples.
