### PR TITLE
Handle simple branch names

### DIFF
--- a/CheckRelease.Tests/CommitAnalyzerTests.cs
+++ b/CheckRelease.Tests/CommitAnalyzerTests.cs
@@ -138,5 +138,128 @@ namespace CheckRelease.Tests
             Assert.Contains(result, c => c.JiraTicketId == "JIRA-789" && c.Description == "Add Another Feature");
             Assert.DoesNotContain(result, c => c.JiraTicketId == "JIRA-456"); // Should be skipped due to _F_ flag
         }
+        
+        [Fact]
+        public void AnalyzeCommits_HandlesSimpleBranchNames_WithoutTitle()
+        {
+            // Arrange
+            var mockRepo = new MockGitRepository();
+            
+            // Add test commits with simple branch names (no title after ticket ID)
+            var commit1 = new GitCommit 
+            { 
+                Sha = "abc1234", 
+                Message = "Merge branch 'JIRA-4789'", // Simple branch name
+                AuthorName = "Test User",
+                AuthorWhen = DateTimeOffset.Now.AddDays(-2),
+                ParentCount = 2 // Merge commit
+            };
+            
+            var commit2 = new GitCommit 
+            { 
+                Sha = "def5678", 
+                Message = "Merge branch 'JIRA-5678'", // Another simple branch name
+                AuthorName = "Test User",
+                AuthorWhen = DateTimeOffset.Now.AddDays(-1),
+                ParentCount = 2 // Merge commit
+            };
+            
+            mockRepo.AddCommit(commit1).AddCommit(commit2);
+            
+            // Setup commit relationships
+            mockRepo.AddCommitRelationship("abc1234", "def5678");
+            
+            // Add tags
+            mockRepo.AddTag(new GitTag 
+            { 
+                Name = "v1.0", 
+                TargetCommitSha = "abc1234",
+                CreatedAt = DateTimeOffset.Now.AddDays(-2)
+            });
+            
+            mockRepo.AddTag(new GitTag 
+            { 
+                Name = "v2.0", 
+                TargetCommitSha = "def5678",
+                CreatedAt = DateTimeOffset.Now.AddDays(-1)
+            });
+            
+            var analyzer = new CommitAnalyzer(mockRepo, "JIRA");
+            
+            // Act
+            var result = analyzer.AnalyzeCommits("v1.0", "v2.0");
+            
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Contains(result, c => c.JiraTicketId == "JIRA-4789" && c.Description == "Ticket JIRA-4789");
+            Assert.Contains(result, c => c.JiraTicketId == "JIRA-5678" && c.Description == "Ticket JIRA-5678");
+        }
+        
+        [Fact]
+        public void AnalyzeCommits_HandlesMixedBranchNames_SimpleAndWithTitle()
+        {
+            // Arrange
+            var mockRepo = new MockGitRepository();
+            
+            // Add test commits with a mix of simple and titled branch names
+            var commit1 = new GitCommit 
+            { 
+                Sha = "abc1234", 
+                Message = "Merge branch 'ELUM-4789'", // Simple branch name
+                AuthorName = "Test User",
+                AuthorWhen = DateTimeOffset.Now.AddDays(-3),
+                ParentCount = 2 // Merge commit
+            };
+            
+            var commit2 = new GitCommit 
+            { 
+                Sha = "def5678", 
+                Message = "Merge branch 'ELUM-5000__BUG_Fix_the_overflow'", // Branch with title
+                AuthorName = "Test User",
+                AuthorWhen = DateTimeOffset.Now.AddDays(-2),
+                ParentCount = 2 // Merge commit
+            };
+            
+            var commit3 = new GitCommit 
+            { 
+                Sha = "ghi9012", 
+                Message = "Merge branch 'ELUM-5100'", // Another simple branch name
+                AuthorName = "Test User",
+                AuthorWhen = DateTimeOffset.Now.AddDays(-1),
+                ParentCount = 2 // Merge commit
+            };
+            
+            mockRepo.AddCommit(commit1).AddCommit(commit2).AddCommit(commit3);
+            
+            // Setup commit relationships
+            mockRepo.AddCommitRelationship("abc1234", "def5678");
+            mockRepo.AddCommitRelationship("def5678", "ghi9012");
+            
+            // Add tags
+            mockRepo.AddTag(new GitTag 
+            { 
+                Name = "v1.0", 
+                TargetCommitSha = "abc1234",
+                CreatedAt = DateTimeOffset.Now.AddDays(-3)
+            });
+            
+            mockRepo.AddTag(new GitTag 
+            { 
+                Name = "v2.0", 
+                TargetCommitSha = "ghi9012",
+                CreatedAt = DateTimeOffset.Now.AddDays(-1)
+            });
+            
+            var analyzer = new CommitAnalyzer(mockRepo, "ELUM");
+            
+            // Act
+            var result = analyzer.AnalyzeCommits("v1.0", "v2.0");
+            
+            // Assert
+            Assert.Equal(3, result.Count);
+            Assert.Contains(result, c => c.JiraTicketId == "ELUM-4789" && c.Description == "Ticket ELUM-4789");
+            Assert.Contains(result, c => c.JiraTicketId == "ELUM-5000" && c.Description == "BUG Fix the overflow");
+            Assert.Contains(result, c => c.JiraTicketId == "ELUM-5100" && c.Description == "Ticket ELUM-5100");
+        }
     }
 }

--- a/CommitAnalyzer.cs
+++ b/CommitAnalyzer.cs
@@ -34,7 +34,10 @@ namespace CheckRelease
             _console = console ?? new Adapters.ConsoleOutput(debugMode);
             
             // Create the regex pattern with the configurable prefix
-            _jiraTicketRegex = new Regex($@"({_prefix}-[0-9]+)_+([A-Za-z0-9_]+)", RegexOptions.Compiled);
+            // This pattern supports both formats:
+            // 1. Simple: JIRA-123 (just the ticket ID)
+            // 2. With title: JIRA-123__Add_Feature (ticket ID followed by underscores and title)
+            _jiraTicketRegex = new Regex($@"({_prefix}-[0-9]+)(?:_+([A-Za-z0-9_]+))?", RegexOptions.Compiled);
         }
         
         /// <summary>
@@ -111,8 +114,12 @@ namespace CheckRelease
                         var jiraId = match.Groups[1].Value;
                         var extraText = match.Groups[2].Value;
                         
-                        // Format the extra text
-                        var formattedText = FormatExtraText(extraText);
+                        // Format the description:
+                        // If there's extra text (title), format it
+                        // If there's no extra text (simple branch name), use "Ticket {ID}"
+                        var formattedText = string.IsNullOrEmpty(extraText) 
+                            ? $"Ticket {jiraId}" 
+                            : FormatExtraText(extraText);
                         
                         // Skip if we've already processed this ticket
                         if (processedTickets.Contains(jiraId))


### PR DESCRIPTION
## Description
This PR enhances the branch name extraction logic in `CommitAnalyzer` to support simple branch names that contain only a ticket ID (e.g., `ELUM-4789`), in addition to the existing format that requires a title (e.g., `ELUM-4789__BUG_Fix_the_overflow`).

Previously, developers were required to include a descriptive title in their branch names. This PR makes the title optional, allowing for simpler branch naming conventions while maintaining full backward compatibility.

**Changes:**
- Updated regex pattern in `CommitAnalyzer.cs` to make the title portion optional: `({PREFIX}-[0-9]+)(?:_+([A-Za-z0-9_]+))?`
- Added logic to generate "Ticket {TICKET-ID}" as the description when no title is provided
- Simple branch names (e.g., `ELUM-4789`) now generate description: "Ticket ELUM-4789"
- Branch names with titles (e.g., `ELUM-4789__BUG_Fix`) continue to generate formatted descriptions: "BUG Fix"

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## SEMVER Impact
- [x] Minor (new features, non-breaking changes)

## How Has This Been Tested?
All tests pass successfully with 88 total tests:

- [x] Added `AnalyzeCommits_HandlesSimpleBranchNames_WithoutTitle` test - Verifies simple branch names without titles are correctly extracted and formatted
- [x] Added `AnalyzeCommits_HandlesMixedBranchNames_SimpleAndWithTitle` test - Verifies mixed scenarios with both simple and titled branch names work together
- [x] All existing tests continue to pass, confirming backward compatibility
- [x] Ran `dotnet test CheckRelease.Tests/CheckRelease.Tests.csproj` - all 88 tests pass

## Checklist:
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (memory bank updated)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A)
